### PR TITLE
Add simple header authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Starts a proxy that listens on a `port` and `endpoint`, and sends messages to th
 
 ```ts
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { startSSEServer } from "mcp-proxy";
+import { headerAuth, startSSEServer } from "mcp-proxy";
 
 const { close } = await startSSEServer({
   port: 8080,
@@ -73,6 +73,7 @@ const { close } = await startSSEServer({
   createServer: async () => {
     return new Server();
   },
+  authenticate: headerAuth,
 });
 
 close();
@@ -84,7 +85,7 @@ Starts a proxy that listens on a `port` and `endpoint`, and sends messages to th
 
 ```ts
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
-import { startHTTPStreamServer, InMemoryEventStore } from "mcp-proxy";
+import { headerAuth, startHTTPStreamServer, InMemoryEventStore } from "mcp-proxy";
 
 const { close } = await startHTTPStreamServer({
   port: 8080,
@@ -93,6 +94,7 @@ const { close } = await startHTTPStreamServer({
     return new Server();
   },
   eventStore: new InMemoryEventStore(), // optional you can provide your own event store
+  authenticate: headerAuth,
 });
 
 close();

--- a/src/headerAuth.ts
+++ b/src/headerAuth.ts
@@ -1,0 +1,10 @@
+import http from "http";
+
+export const AUTH_USER_ID = "user123";
+
+export const headerAuth = (req: http.IncomingMessage): boolean => {
+  const value = Array.isArray(req.headers["x-user-id"])
+    ? req.headers["x-user-id"][0]
+    : req.headers["x-user-id"];
+  return value === AUTH_USER_ID;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export { startHTTPStreamServer } from "./startHTTPStreamServer.js";
 export { startSSEServer } from "./startSSEServer.js";
 export { ServerType, startStdioServer } from "./startStdioServer.js";
 export { tapTransport } from "./tapTransport.js";
+export { headerAuth } from "./headerAuth.js";

--- a/src/startHTTPStreamServer.ts
+++ b/src/startHTTPStreamServer.ts
@@ -19,6 +19,7 @@ type ServerLike = {
 };
 
 export const startHTTPStreamServer = async <T extends ServerLike>({
+  authenticate,
   createServer,
   endpoint,
   eventStore,
@@ -27,6 +28,7 @@ export const startHTTPStreamServer = async <T extends ServerLike>({
   onUnhandledRequest,
   port,
 }: {
+  authenticate?: (req: http.IncomingMessage) => boolean | Promise<boolean>;
   createServer: (request: http.IncomingMessage) => Promise<T>;
   endpoint: string;
   eventStore?: EventStore;
@@ -71,6 +73,11 @@ export const startHTTPStreamServer = async <T extends ServerLike>({
 
     if (req.method === "GET" && req.url === `/ping`) {
       res.writeHead(200).end("pong");
+      return;
+    }
+
+    if (authenticate && !(await authenticate(req))) {
+      res.writeHead(401).end("Unauthorized");
       return;
     }
 

--- a/src/startSSEServer.ts
+++ b/src/startSSEServer.ts
@@ -12,6 +12,7 @@ type ServerLike = {
 };
 
 export const startSSEServer = async <T extends ServerLike>({
+  authenticate,
   createServer,
   endpoint,
   onClose,
@@ -19,6 +20,7 @@ export const startSSEServer = async <T extends ServerLike>({
   onUnhandledRequest,
   port,
 }: {
+  authenticate?: (req: http.IncomingMessage) => boolean | Promise<boolean>;
   createServer: (request: http.IncomingMessage) => Promise<T>;
   endpoint: string;
   onClose?: (server: T) => void;
@@ -62,6 +64,11 @@ export const startSSEServer = async <T extends ServerLike>({
     if (req.method === "GET" && req.url === `/ping`) {
       res.writeHead(200).end("pong");
 
+      return;
+    }
+
+    if (authenticate && !(await authenticate(req))) {
+      res.writeHead(401).end("Unauthorized");
       return;
     }
 


### PR DESCRIPTION
## Summary
- allow optional `authenticate` handler for startSSEServer and startHTTPStreamServer
- add utility `headerAuth` for simple header-based user id check
- document authentication feature in README

## Testing
- `pnpm test` *(fails: vitest not found)*