### PR TITLE
Add simple header authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ options:
 - `--endpoint`: Specify the endpoint to listen on (default: `/sse` for SSE server, `/stream` for stream server)
 - `--server`: Specify the server type to use (default: `sse`)
 - `--debug`: Enable debug logging
+- `--user-id`: Require this value in the `x-user-id` header before tools can be used
 
 ### Node.js SDK
 
@@ -54,6 +55,20 @@ proxyServer({
   server,
   client,
   capabilities: {},
+});
+```
+
+The proxy supports optional authentication. Provide an `authenticate`
+function along with the HTTP `request` used to create the server. Tool
+requests will only be processed when authentication succeeds.
+
+```ts
+proxyServer({
+  server,
+  client,
+  capabilities: {},
+  authenticate: createHeaderAuth("user123"),
+  request,
 });
 ```
 

--- a/src/headerAuth.ts
+++ b/src/headerAuth.ts
@@ -1,0 +1,15 @@
+import http from "http";
+
+export const createHeaderAuth = (userId: string) => {
+  return (req: http.IncomingMessage): boolean => {
+    const value = Array.isArray(req.headers["x-user-id"])
+      ? req.headers["x-user-id"][0]
+      : req.headers["x-user-id"];
+
+    return value === userId;
+  };
+};
+
+export const AUTH_USER_ID = "user123";
+
+export const headerAuth = createHeaderAuth(AUTH_USER_ID);

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,4 @@ export { startHTTPStreamServer } from "./startHTTPStreamServer.js";
 export { startSSEServer } from "./startSSEServer.js";
 export { ServerType, startStdioServer } from "./startStdioServer.js";
 export { tapTransport } from "./tapTransport.js";
+export { createHeaderAuth, headerAuth } from "./headerAuth.js";


### PR DESCRIPTION
## Summary
- support authentication at tool invocation via `proxyServer`
- add CLI `--user-id` flag to enforce header auth
- remove connection-time header checks in server helpers
- document optional tool authentication in README

## Testing
- `pnpm test` *(fails: vitest not found)*