### PR TITLE
Add helper for authenticated SSE client

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,17 @@ const transport = tapTransport(new StdioClientTransport(), (event) => {
   console.log(event);
 });
 ```
+
+#### `createAuthenticatedSSEClientTransport`
+
+Creates an `SSEClientTransport` that automatically adds an `x-user-id` header to
+both the initial SSE connection and subsequent POST requests.
+
+```ts
+import { createAuthenticatedSSEClientTransport } from "mcp-proxy";
+
+const transport = createAuthenticatedSSEClientTransport(
+  new URL("http://localhost:8080/sse"),
+  "user123",
+);
+```

--- a/src/authenticatedSSEClientTransport.ts
+++ b/src/authenticatedSSEClientTransport.ts
@@ -1,0 +1,24 @@
+import { SSEClientTransport, SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js";
+
+/**
+ * Create an SSE client transport that always sends the provided `x-user-id`
+ * header when establishing the SSE connection and when POSTing messages.
+ */
+export const createAuthenticatedSSEClientTransport = (
+  url: URL,
+  userId: string,
+  options: SSEClientTransportOptions = {},
+): SSEClientTransport => {
+  const headers = { "x-user-id": userId };
+  return new SSEClientTransport(url, {
+    ...options,
+    eventSourceInit: {
+      ...(options.eventSourceInit ?? {}),
+      headers: { ...(options.eventSourceInit?.headers ?? {}), ...headers },
+    },
+    requestInit: {
+      ...(options.requestInit ?? {}),
+      headers: { ...(options.requestInit?.headers ?? {}), ...headers },
+    },
+  });
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export { startSSEServer } from "./startSSEServer.js";
 export { ServerType, startStdioServer } from "./startStdioServer.js";
 export { tapTransport } from "./tapTransport.js";
 export { createHeaderAuth, headerAuth } from "./headerAuth.js";
+export { createAuthenticatedSSEClientTransport } from "./authenticatedSSEClientTransport.js";

--- a/src/startSSEServer.test.ts
+++ b/src/startSSEServer.test.ts
@@ -1,5 +1,4 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { EventSource } from "eventsource";
@@ -9,6 +8,8 @@ import { expect, it, vi } from "vitest";
 
 import { proxyServer } from "./proxyServer.js";
 import { startSSEServer } from "./startSSEServer.js";
+import { AUTH_USER_ID, headerAuth } from "./headerAuth.js";
+import { createAuthenticatedSSEClientTransport } from "./authenticatedSSEClientTransport.js";
 
 if (!("EventSource" in global)) {
   // @ts-expect-error - figure out how to use --experimental-eventsource with vitest
@@ -63,6 +64,7 @@ it("proxies messages between SSE and stdio servers", async () => {
       return mcpServer;
     },
     endpoint: "/sse",
+    authenticate: headerAuth,
     onClose,
     onConnect,
     port,
@@ -78,8 +80,9 @@ it("proxies messages between SSE and stdio servers", async () => {
     },
   );
 
-  const transport = new SSEClientTransport(
+  const transport = createAuthenticatedSSEClientTransport(
     new URL(`http://localhost:${port}/sse`),
+    AUTH_USER_ID,
   );
 
   await sseClient.connect(transport);


### PR DESCRIPTION
## Summary
- add `createAuthenticatedSSEClientTransport` helper
- export new helper from library
- document how to use the helper in README
- test SSE auth using the helper and header authentication

## Testing
- `npm test` *(fails: vitest not found)*